### PR TITLE
Chaining

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,17 +172,21 @@ if let c: Color = xml.product.catalog_item.size.color_swatch.enum() {
 
 ```swift
 let store = XML(name: "store")
-store.addAttribute(name: "description", value: "Ball Store")
+    .addAttribute(name: "description", value: "Ball Store")
+    .addChildren([
+        // attributes can be added in the initializer
+        XML(name: "product", attributes: [
+            "name": "football",
+            "weight": 0.453
+        ])
+    ])
 
-let product1 = XML(name: "product")
-product1.addAttribute(name: "name", value: "football")
-product1.addAttribute(name: "weight", value: 0.453)
-
+// attributes can be added to an existing object
 let product2 = XML(name: "product")
 product2.addAttribute(name: "name", value: "basketball")
 product2.addAttribute(name: "weight", value: 0.654)
 
-store.addChild(product1)
+// children can be added to an existing object
 store.addChild(product2)
 
 print(store.toXMLString())

--- a/Sources/SwiftyXML/XML.swift
+++ b/Sources/SwiftyXML/XML.swift
@@ -279,26 +279,34 @@ open class XML {
         }
     }
     
-    public func addAttribute(name:String, value:Any) {
+    @discardableResult
+    public func addAttribute(name:String, value:Any) -> XML {
         self.attributes[name] = String(describing: value)
+        return self
     }
     
-    public func addAttributes(_ attributes:[String : Any]) {
+    @discardableResult
+    public func addAttributes(_ attributes:[String : Any]) -> XML {
         for (key, value) in attributes {
             self.addAttribute(name: key, value: value)
         }
+        return self
     }
     
-    public func addChild(_ xml:XML) {
+    @discardableResult
+    public func addChild(_ xml:XML) -> XML {
         guard xml !== self else {
             fatalError("can not add self to xml children list!")
         }
         children.append(xml)
         xml.parent = self
+        return self
     }
     
-    public func addChildren(_ xmls: [XML]) {
+    @discardableResult
+    public func addChildren(_ xmls: [XML]) -> XML {
         xmls.forEach{ self.addChild($0) }
+        return self
     }
 }
 


### PR DESCRIPTION
Allow `addAttribute` and `addChild` calls to be chained to XML objects. This allows XML objects to be created without needing to define any variables.

Example:

You can generate the XML

```xml
<rss version="2.0">
    <channel>
        <title>Example Title</title>
        <description>Example Description</description>
        <item>
            <title>Episode 0</title>
        </item>
    </channel>
</rss>
```

in a single go:

```swift
XML(name: "rss")
    .addAttribute(name: "version", value: "2.0")
    .addChildren([
        XML(name: "channel").addChildren([
            XML(name: "title", value: "Example Title"),
            XML(name: "description", value: "Example Description"),
            XML(name: "item").addChildren([
                XML(name: "title", value: "Episode 0")
            ])
        ])
    ])
```