### PR TITLE
Amended public XML element properties

### DIFF
--- a/Sources/SwiftyXML/XML.swift
+++ b/Sources/SwiftyXML/XML.swift
@@ -180,11 +180,25 @@ public enum XMLSubscriptResult {
 @dynamicMemberLookup
 open class XML {
     
-    public var name:String
-    public var attributes:[String: String] = [:]
-    public var value:String?
-    public internal(set) var children:[XML] = []
+    fileprivate var name:String
+    fileprivate var attributes:[String: String] = [:]
+    fileprivate var value:String?
+    fileprivate var children:[XML] = []
     
+    public var xmlName:String {
+        get { name }
+        set { name = newValue }
+    }
+    public var xmlAttributes:[String: String] {
+        get { attributes }
+        set { attributes = newValue }
+    }
+    public var xmlValue:String? {
+        get { value }
+        set { value = newValue }
+    }
+    public var xmlChildren:[XML] { children }
+
     internal weak var parent:XML?
     
     public init(name:String, attributes:[String:Any] = [:], value: Any? = nil) {


### PR DESCRIPTION
The public properties of the XML class (name, attributes, value and children) can mask child XML elements with the same element name when attempting to use DynamicMemberLookup to traverse the XML chain. As the definition of XML element naming at https://www.w3schools.com indicates that an element cannot be given a name starting with xml, I have renamed the 4 public properties listed here with the prefix xml... (creating public properties named xmlName, xmlAttributes, xmlValue and xmlChildren).

This is to correct a real-world situation where full traversal of the xml tree of the GPX file format (https://en.wikipedia.org/wiki/GPS_Exchange_Format) using DynamicMemberLookup is impossible because of child elements named as "name" in the wptType, rteType, trkType and personType elements.